### PR TITLE
今回のeslint仕様に合わせて変更

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,4 @@ build
 coverage
 *.java
 *.class
-backend/
+backend/**

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -2,7 +2,7 @@
 
 // TypeScriptが.vueファイルを認識できるようにするための型定義
 declare module '*.vue' {
-  import { DefineComponent } from 'vue'
-  const component: DefineComponent<{}, {}, any>
-  export default component
+  import { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>;
+  export default component;
 }

--- a/frontend/src/components/TestComponent.vue
+++ b/frontend/src/components/TestComponent.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="test">
     <p>Prettier テスト</p>
+    <p>{{ greeting }}</p>
   </div>
 </template>
 
-<script setup>
-  const name = 'Test User' // ← セミコロンが付いている (semi: false 違反)
-  const greeting = 'Hello, ' + name + '!' // ← セミコロンが付いている (semi: false 違反)
+<script setup lang="ts">
+  const name = 'Test User';
+  const greeting = 'Hello, ' + name + '!';
 </script>
 
 <style scoped>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "lint-staged": {
-    "**/*.{js,ts,tsx,jsx,json,css,md}": [
+    "frontend/**/*.{js,ts,tsx,vue}": [
+      "prettier --write",
+      "npm --prefix frontend run lint"
+    ],
+    "frontend/**/*.{json,css,scss,md}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
元々root側に移動させる予定でしたが、ESLintは`Vue依存性`のためfrontendに置くのが正しく、lint-stagedはルートに置いてコミット時にeslintを実行する役割だけをすると、両方とも互換性があるようにうまく作動します。