### PR TITLE
EditorConfig適用完了してメインにマージ作業

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# Editor Configは、ファイル別のフォーマッティングプロパティを定義
+root = true
+
+# 基本属性定義
+[*]
+indent_style = space            # スペースインデント
+indent_size = 2                 # インデントサイズ: 2
+end_of_line = lf                # 改行文字: LF
+charset = utf-8                 # ファイルエンコーディング: UTF-8
+trim_trailing_whitespace = true # 行末の空白の除去
+insert_final_newline = true     # ファイルの最後の改行強制
+
+# よく使用するファイルタイプ
+[*.{js,jsx,ts,tsx,vue,css,scss,sass,less,styl}]
+indent_size = 2
+indent_style = space
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+# Markdownファイルは最後の改行強制X
+[*.md]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+# JSONファイルは2間スペース
+[*.{json}]
+indent_style = space
+indent_size = 2
+
+# YAMLファイルも同一
+[*.yml]
+indent_style = space
+indent_size = 2
+
+# Javaファイルは4間スペースの例
+[*.java]
+indent_style = space
+indent_size = 4

--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -1,9 +1,0 @@
-[*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,vue,css,scss,sass,less,styl}]
-charset = utf-8
-indent_size = 2
-indent_style = space
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-end_of_line = lf
-max_line_length = 100

--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -1,7 +1,7 @@
-import { globalIgnores } from 'eslint/config'
-import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
-import pluginVue from 'eslint-plugin-vue'
-import skipFormatting from '@vue/eslint-config-prettier/skip-formatting'
+import { globalIgnores } from 'eslint/config';
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript';
+import pluginVue from 'eslint-plugin-vue';
+import skipFormatting from '@vue/eslint-config-prettier/skip-formatting';
 
 // To allow more languages other than `ts` in `.vue` files, uncomment the following lines:
 // import { configureVueProject } from '@vue/eslint-config-typescript'
@@ -18,5 +18,5 @@ export default defineConfigWithVueTs(
 
   pluginVue.configs['flat/essential'],
   vueTsConfigs.recommended,
-  skipFormatting,
-)
+  skipFormatting
+);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,11 +1,11 @@
-import './assets/main.css'
+import './assets/main.css';
 
-import { createApp } from 'vue'
-import App from './App.vue'
-import router from './router'
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
 
-const app = createApp(App)
+const app = createApp(App);
 
-app.use(router)
+app.use(router);
 
-app.mount('#app')
+app.mount('#app');

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,16 +2,17 @@
 /**
  * ? Vue Routerの設定ファイルです。
  */
-import { createRouter, createWebHistory } from 'vue-router'
-import HomeView from '../views/HomeView.vue'
+import { createRouter, createWebHistory } from 'vue-router';
+import HomeView from '../views/HomeView.vue';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.VITE_BASE_URL), // .env環境変数から取得
-  routes: [ // ルートの定義
+  routes: [
+    // ルートの定義
     {
-      path: '/',              // ルートパス
-      name: 'home',           // 内部で使用するルート名
-      component: HomeView,    // ルートに対応するコンポーネント
+      path: '/', // ルートパス
+      name: 'home', // 内部で使用するルート名
+      component: HomeView, // ルートに対応するコンポーネント
     },
     {
       path: '/about',
@@ -24,6 +25,6 @@ const router = createRouter({
       component: () => import('../views/AboutView.vue'),
     },
   ],
-})
+});
 
-export default router
+export default router;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,22 +1,19 @@
-import { fileURLToPath, URL } from 'node:url'
-import { defineConfig, loadEnv } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import vueDevTools from 'vite-plugin-vue-devtools'
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig, loadEnv } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vueDevTools from 'vite-plugin-vue-devtools';
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd()) // 環境変数ローディング
+  const env = loadEnv(mode, process.cwd()); // 環境変数ローディング
 
   return {
     base: env.VITE_BASE_URL, // .envから取得した値を使用
-    plugins: [
-      vue(),
-      vueDevTools(),
-    ],
+    plugins: [vue(), vueDevTools()],
     resolve: {
       alias: {
-        '@': fileURLToPath(new URL('./src', import.meta.url))
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
     },
-  }
-})
+  };
+});


### PR DESCRIPTION
- VSCodeのExtensionsで以下をインストールします。
[EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
- root側に`.editorconfig`を追加して適用します。
> ※vue3を構築した時に生成されたfrontend側の.editorconfigは削除処理。（root側で管理）