### PR TITLE
Refactor,Build: DBコンテナ構築及びdocker-compose作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ cypress/screenshots/
 # 環境変数（今回はテスト構築なのでコメントアウト。今後.gitignoreに追加必須）
 #.env
 #.env.*.local
+
+# db volumes
+pgdata/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: app:0.0.1
+    container_name: app
+    ports:
+      - '8080:8080'
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/mydb
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15.13
+    container_name: db
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: mydb
+    ports:
+      - '5432:5432'
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data


### PR DESCRIPTION
- `docker-compose.yml`作成済み
> コンテナ生成及びビルドするため作成しました。
---
#### pgdataについて
- PostgreSQLコンテナの内部データディレクトリーがローカルにマッピングされる`ボリュームデータ`
- DBのデータファイル、トランザクションログ、WAL、メタデータなど、すべてのデータベースの状態情報が含まれています。
- 容量もどんどん大きくなり、バイナリファイルなのでGitヒストリーに大きな負担を与えます。

→`.gitignore`に`pgdata`を追加
> ローカルではdocker-composeでコンテナを浮かせる度に`pgdata`は自動的に生成