### PR TITLE
Fix: dockerのイメージ修正（postgres:15.10）

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - db
 
   db:
-    image: postgres:15.13
+    image: postgres:15.10
     container_name: db
     restart: always
     environment:


### PR DESCRIPTION
本日（2025.07.01）のMTGの上、修正事項あり
- ローカル環境のPostgreSQLと関係ないので、Docker HUBのイメージに合わせる。
- `15.13` → `15.10`に変更あり