### PR TITLE
docker 拡張名を見やすく変更してマージ作業

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - [Visual Studio Code](https://code.visualstudio.com/)
   - **拡張（必須）**:
     - Spring Boot Extension Pack
-    - Docker
+    - [Docker Extension Pack for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
     - Extension Pack for Java
     - EditorConfig for VS Code
       - `.editorconfig` ファイルは、コードフォーマットのルールを定義しています。


### PR DESCRIPTION
slack よりお話がありました。
> `Visual Studio Code`　の拡張で、Docker　がありますが
> `Docker Extension Pack for Visual Studio Code`　にした方がわかりやすいかと思います

おっしゃった通りに修正した方が、私としてもより見やすくなると感じましたので、修正しました。