### PR TITLE
google-java-format 適用後の java ファイルをメインにマージ作業

### DIFF
--- a/backend/src/main/java/com/example/demo/LambdaHandler.java
+++ b/backend/src/main/java/com/example/demo/LambdaHandler.java
@@ -1,18 +1,14 @@
 package com.example.demo;
 
-import java.util.Map;
-
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import java.util.Map;
 
 public class LambdaHandler implements RequestHandler<Map<String, Object>, Map<String, Object>> {
 
-    @Override
-    public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
-        context.getLogger().log("Received event: " + event);
-        return Map.of(
-            "statusCode", 200,
-            "body", "LocalStack Java Lambda からの応答です！"
-        );
-    }
+  @Override
+  public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
+    context.getLogger().log("Received event: " + event);
+    return Map.of("statusCode", 200, "body", "LocalStack Java Lambda からの応答です！");
+  }
 }


### PR DESCRIPTION
ルート側の `.vscode` の `settings.json` に `google-java-format` を追加して **java フォーマットとして**適用しました。
> ※以前はVSCodeの拡張はダウンロードしましたが、フォーマットとしては適用しませんでした。

その結果、`LamdaHandler.java` の修正がありました。（※git コミット内容参照）

以下は今回適用された `google-java-format` 修正内容です。
- インデント 4個 → 2個 に変更あり。
  - Google Java Styleは2個インデントを基本とします。
- import 再整列
  - Googleはアルファベット基準のソートの代わりに、importグループをソートします。
  - → `com.` → `java.` 順に並べ替えられます。
- `return Map.of(...)` フォーマット
  - Google Formatは可能な場合、一行に表現します。
